### PR TITLE
Suppress or fix all compiler warnings

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -4,19 +4,20 @@ use nom::Err;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ErrorKindExt {
-    // TODO: Unify into one generic error with data
-    InvalidSfntVersion,
-    InvalidTableTag,
     InvalidIndexToLocFormat
 }
 
 impl ErrorKindExt {
     pub fn description(&self) -> &str {
         match *self {
-            ErrorKindExt::InvalidSfntVersion => "Invalid OpenType fonts content type",
-            ErrorKindExt::InvalidTableTag => "Invalid table tag",
             ErrorKindExt::InvalidIndexToLocFormat => "Invalid indexToLocFormat entry",
         }
+    }
+}
+
+impl Display for ErrorKindExt {
+    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(self.description())
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -2,7 +2,7 @@ use std::fmt::{self, Display};
 use std::error;
 use nom::Err;
 
-#[derive(Debug, Copy, Clone,PartialEq,Eq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub enum ErrorKindExt {
     // TODO: Unify into one generic error with data
     InvalidSfntVersion,

--- a/src/font.rs
+++ b/src/font.rs
@@ -1,8 +1,7 @@
-use error::Error;
 use offset_table::OffsetTable;
 use std::ops;
 use table::Table;
-use tables::{TableTag, Tag};
+use tables::TableTag;
 use table_record::parse_table_record;
 
 pub struct Font<'otf> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,8 +14,8 @@ mod offset_table;
 mod otff;
 mod table;
 mod table_record;
-pub mod traits;
 mod ttc_header;
+pub mod traits;
 pub mod tables;
 pub mod types;
 

--- a/src/otff.rs
+++ b/src/otff.rs
@@ -1,7 +1,6 @@
 use error::Error;
 use font::Font;
 use offset_table::{OffsetTable, parse_offset_table};
-use table_record::parse_table_records;
 use ttc_header::{TTCHeader, parse_ttc_header};
 
 /// An OpenType font file contains data, in table format, that comprises either a TrueType or a
@@ -81,7 +80,7 @@ impl<'otf> Iterator for OpenTypeFontFileIterator<'otf> {
                     Some(Font::new(self.otff.buf, self.otff.remainder, *offset_table))
                 }
             },
-            OpenTypeFontKind::FontCollection(ttc_header) => {
+            OpenTypeFontKind::FontCollection(_ttc_header) => {
                 // TODO
                 None
             }
@@ -111,7 +110,6 @@ named!(pub parse_otff<&[u8],OpenTypeFontKind>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context, Needed};
     use offset_table::SfntVersion;
 
     #[test]

--- a/src/otff.rs
+++ b/src/otff.rs
@@ -13,7 +13,6 @@ use ttc_header::{TTCHeader, parse_ttc_header};
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum OpenTypeFontKind {
     Font(OffsetTable),
-
     FontCollection(TTCHeader)
 }
 

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,6 +1,5 @@
 use error::Error;
-use tables::{TableTag, Tag};
-use std::{fmt, cmp, ops};
+use tables::TableTag;
 use table_record::{compute_checksum, compute_checksum_for_head};
 
 pub struct Table<'otf> {
@@ -38,7 +37,7 @@ impl<'otf> Table<'otf> {
             TableTag::Head => {
                 let checksum = compute_checksum_for_head(table_padded_buf)?;
 
-                if (checksum != self.check_sum) {
+                if checksum != self.check_sum {
                     return Err(Error::new(format!("Invalid checksum: expected {} got {}", self.check_sum, checksum)))
                 }
 
@@ -47,7 +46,7 @@ impl<'otf> Table<'otf> {
             _ => {
                 let checksum = compute_checksum(table_padded_buf)?;
 
-                if (checksum != self.check_sum) {
+                if checksum != self.check_sum {
                     return Err(Error::new(format!("Invalid checksum: expected {} got {}", self.check_sum, checksum)))
                 }
 

--- a/src/table_record.rs
+++ b/src/table_record.rs
@@ -94,7 +94,6 @@ pub fn compute_checksum_for_head(i: &[u8]) -> Result<u32, Error> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context};
     use tables::TableTag;
 
     static ROBOTO_REGULAR: &[u8] = include_bytes!("../fonts/Roboto/Roboto-Regular.ttf");

--- a/src/table_record.rs
+++ b/src/table_record.rs
@@ -17,6 +17,7 @@ pub struct TableRecord {
 }
 
 impl TableRecord {
+    #[allow(dead_code)]
     pub(crate) fn new(table_tag: Tag, check_sum: u32, offset: Offset32, length: u32) -> TableRecord {
         TableRecord {
             table_tag,

--- a/src/tables/cmap.rs
+++ b/src/tables/cmap.rs
@@ -2,7 +2,6 @@ use error::Error;
 use nom::{be_u8, be_i16, be_u16, be_u24, be_u32};
 use tables::name::Platform;
 use std::collections::HashMap;
-use std::fmt;
 use traits::{Parser, TableParser};
 use super::GlyphId;
 
@@ -168,7 +167,7 @@ impl<'otf> CharacterGlyphIndexMappingSubtable<'otf> {
             CharacterGlyphIndexMappingSubtable::Format_10(subtable) => subtable.language(),
             CharacterGlyphIndexMappingSubtable::Format_12(subtable) => subtable.language(),
             CharacterGlyphIndexMappingSubtable::Format_13(subtable) => subtable.language(),
-            CharacterGlyphIndexMappingSubtable::Format_14(subtable) => 0
+            CharacterGlyphIndexMappingSubtable::Format_14(_subtable) => 0
         }
     }
 
@@ -181,8 +180,8 @@ impl<'otf> CharacterGlyphIndexMappingSubtable<'otf> {
 
                 Some(subtable.get_glyph_id(character_code as u8))
             },
-            CharacterGlyphIndexMappingSubtable::Format_2(subtable) => None,
-            CharacterGlyphIndexMappingSubtable::Format_4(subtable) => None,
+            CharacterGlyphIndexMappingSubtable::Format_2(_subtable) => None,
+            CharacterGlyphIndexMappingSubtable::Format_4(_subtable) => None,
             CharacterGlyphIndexMappingSubtable::Format_6(subtable) => {
                 if character_code > u32::from(u16::max_value()) {
                     return None;
@@ -190,11 +189,11 @@ impl<'otf> CharacterGlyphIndexMappingSubtable<'otf> {
 
                 subtable.get_glyph_id(character_code as u16)
             },
-            CharacterGlyphIndexMappingSubtable::Format_8(subtable) => None,
-            CharacterGlyphIndexMappingSubtable::Format_10(subtable) => None,
-            CharacterGlyphIndexMappingSubtable::Format_12(subtable) => None,
-            CharacterGlyphIndexMappingSubtable::Format_13(subtable) => None,
-            CharacterGlyphIndexMappingSubtable::Format_14(subtable) => None
+            CharacterGlyphIndexMappingSubtable::Format_8(_subtable) => None,
+            CharacterGlyphIndexMappingSubtable::Format_10(_subtable) => None,
+            CharacterGlyphIndexMappingSubtable::Format_12(_subtable) => None,
+            CharacterGlyphIndexMappingSubtable::Format_13(_subtable) => None,
+            CharacterGlyphIndexMappingSubtable::Format_14(_subtable) => None
         }
     }
 
@@ -392,7 +391,7 @@ impl<'otf> CharacterGlyphIndexMappingSubtable4<'otf> {
         &self.id_range_offset
     }
 
-    pub fn get_glyph_id(&self, character_code: u16) -> Option<GlyphId> {
+    pub fn get_glyph_id(&self, _character_code: u16) -> Option<GlyphId> {
         None
     }
 
@@ -919,7 +918,7 @@ named!(pub parse_character_to_glyph_index_mapping_subtable<&[u8],CharacterGlyphI
 named!(parse_character_to_glyph_index_mapping_subtable_0<&[u8],CharacterGlyphIndexMappingSubtable>,
     do_parse!(
         verify!(be_u16, |format| format == 0) >>
-        length: be_u16 >>
+        _length: be_u16 >>
         language: be_u16 >>
         glyph_id_array: take!(256) >>
         (
@@ -934,7 +933,7 @@ named!(parse_character_to_glyph_index_mapping_subtable_0<&[u8],CharacterGlyphInd
 named!(parse_character_to_glyph_index_mapping_subtable_2<&[u8],CharacterGlyphIndexMappingSubtable>,
     do_parse!(
         verify!(be_u16, |format| format == 2) >>
-        length: be_u16 >>
+        _length: be_u16 >>
         language: be_u16 >>
         sub_header_keys: count!(be_u16, 256) >>
         (
@@ -993,7 +992,7 @@ fn get_glyph_id_count(seg_count: u16, start_code: &Vec<u16>, end_code: &Vec<u16>
 named!(pub parse_character_to_glyph_index_mapping_subtable_4<&[u8],CharacterGlyphIndexMappingSubtable>,
     do_parse!(
         verify!(be_u16, |format| format == 4) >>
-        length: be_u16 >>
+        _length: be_u16 >>
         language: be_u16 >>
         seg_count: map!(verify!(be_u16, |val| val > 0 && val % 2 == 0),
             |seg_count_x2| seg_count_x2 << 1) >>
@@ -1028,7 +1027,7 @@ named!(pub parse_character_to_glyph_index_mapping_subtable_4<&[u8],CharacterGlyp
 named!(parse_character_to_glyph_index_mapping_subtable_6<&[u8],CharacterGlyphIndexMappingSubtable>,
     do_parse!(
         verify!(be_u16, |format| format == 6) >>
-        length: be_u16 >>
+        _length: be_u16 >>
         language: be_u16 >>
         first_code: be_u16 >>
         entry_count: be_u16 >>
@@ -1049,7 +1048,7 @@ named!(parse_character_to_glyph_index_mapping_subtable_8<&[u8],CharacterGlyphInd
         verify!(be_u16, |format| format == 8) >>
         // Reserved; set to 0
         take!(2) >>
-        length: be_u32 >>
+        _length: be_u32 >>
         language: be_u32 >>
         is32: take!(8192) >>
         groups: length_count!(be_u32, parse_sequential_map_group) >>
@@ -1098,7 +1097,7 @@ named!(parse_character_to_glyph_index_mapping_subtable_10<&[u8],CharacterGlyphIn
         verify!(be_u16, |format| format == 10) >>
         // Reserved; set to 0
         take!(2) >>
-        length: be_u32 >>
+        _length: be_u32 >>
         language: be_u32 >>
         start_char_code: be_u32 >>
         num_chars: be_u32 >>
@@ -1118,7 +1117,7 @@ named!(parse_character_to_glyph_index_mapping_subtable_12<&[u8],CharacterGlyphIn
         verify!(be_u16, |format| format == 12) >>
         // Reserved; set to 0
         take!(2) >>
-        length: be_u32 >>
+        _length: be_u32 >>
         language: be_u32 >>
         groups: length_count!(be_u32, parse_sequential_map_group) >>
         (
@@ -1135,7 +1134,7 @@ named!(parse_character_to_glyph_index_mapping_subtable_13<&[u8],CharacterGlyphIn
         verify!(be_u16, |format| format == 13) >>
         // Reserved; set to 0
         take!(2) >>
-        length: be_u32 >>
+        _length: be_u32 >>
         language: be_u32 >>
         groups: length_count!(be_u32, parse_constant_map_group) >>
         (
@@ -1150,7 +1149,7 @@ named!(parse_character_to_glyph_index_mapping_subtable_13<&[u8],CharacterGlyphIn
 named!(parse_character_to_glyph_index_mapping_subtable_14<&[u8],CharacterGlyphIndexMappingSubtable>,
     do_parse!(
         verify!(be_u16, |format| format == 14) >>
-        length: be_u32 >>
+        _length: be_u32 >>
         var_selector: length_count!(be_u32, parse_variation_selector_record) >>
         (
             CharacterGlyphIndexMappingSubtable::Format_14(CharacterGlyphIndexMappingSubtable14 {

--- a/src/tables/hhea.rs
+++ b/src/tables/hhea.rs
@@ -1,5 +1,5 @@
 use error::Error;
-use nom::{be_i16, be_u16, be_i32, be_u32, be_i64};
+use nom::{be_i16, be_u16};
 use traits::{Parser, TableParser};
 
 /// Horizontal Header Table
@@ -166,7 +166,7 @@ named!(pub parse_horizontal_header_table<&[u8],HorizontalHeaderTable>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context, Needed};
+    use nom::{Err, Needed};
 
     #[test]
     fn case_head_invalid_empty_slice() {

--- a/src/tables/hmtx.rs
+++ b/src/tables/hmtx.rs
@@ -1,5 +1,5 @@
 use error::Error;
-use nom::{be_i16, be_u16, be_i32, be_u32, be_i64, IResult};
+use nom::{be_i16, be_u16, IResult};
 
 /// Horizontal Metrics Table
 ///
@@ -163,7 +163,7 @@ named!(parse_long_hor_metric_record<&[u8],LongHorMetricRecord>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context, Needed};
+    use nom::{Err, Needed};
 
     #[test]
     fn case_horizontal_metrics_table_left_side_bearings() {

--- a/src/tables/loca.rs
+++ b/src/tables/loca.rs
@@ -28,7 +28,7 @@ pub enum IndexToLocationTable {
 }
 
 impl<'otf> IndexToLocationTable {
-    fn get_glyf_offset(&self, glyph_index: u32) -> Option<u32> {
+    pub fn get_glyf_offset(&self, glyph_index: u32) -> Option<u32> {
         match self {
             IndexToLocationTable::Short(offsets) => offsets.get(glyph_index as usize).map(
                 |offset| *offset as u32),

--- a/src/tables/maxp.rs
+++ b/src/tables/maxp.rs
@@ -1,7 +1,6 @@
 use error::Error;
-use nom::{be_i16, be_u16, be_i32, be_u32, be_i64};
+use nom::{be_u16, be_i32};
 use traits::{Parser, TableParser};
-use types::{Fixed, LongDateTime, Rect};
 
 /// Maximum Profile Table
 ///
@@ -235,7 +234,7 @@ named!(parse_maximum_profile_table_v1_0<&[u8],MaximumProfileTable>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context, Needed};
+    use nom::{Err, Needed};
 
     #[test]
     fn case_maximum_profile_table_invalid_empty_slice() {

--- a/src/tables/name.rs
+++ b/src/tables/name.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 use error::Error;
 use nom::be_u16;
 use traits::{Parser, TableParser};

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -1,5 +1,5 @@
 use error::Error;
-use nom::{be_i16, be_u16, be_i32, be_u32, be_i64};
+use nom::{be_i16, be_u16};
 use std::ops;
 use traits::{Parser, TableParser};
 use tables::Tag;
@@ -1898,7 +1898,7 @@ named!(parse_os2v5<&[u8],Os2V5>,
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context, Needed};
+    use nom::{Err, Needed};
 
     #[test]
     fn case_os2_invalid_empty_slice() {

--- a/src/tables/os2.rs
+++ b/src/tables/os2.rs
@@ -1,5 +1,5 @@
 use error::Error;
-use nom::{be_i16, be_u16};
+use nom::{be_i16, be_u16, be_u32};
 use std::ops;
 use traits::{Parser, TableParser};
 use tables::Tag;

--- a/src/tables/post.rs
+++ b/src/tables/post.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 use error::Error;
 use nom::{be_u8, be_i16, be_u16, be_i32, be_u32, IResult};
 use std::{ops, str};
@@ -168,7 +170,7 @@ impl<'otf> Parser<'otf> for PostScriptTable {
 impl<'otf> TableParser<'otf> for PostScriptTable {}
 
 #[derive(Debug, Clone, Eq, PartialEq)]
-#[allow(non_camel_case_types)]
+#[allow(non_camel_case_types, deprecated)]
 pub enum PostScriptVersion {
     /// This version is used in order to supply PostScript glyph names when the font file contains
     /// exactly the 258 glyphs in the standard Macintosh TrueType font file (see 'post' Format 1 in
@@ -417,7 +419,7 @@ pub fn parse_pascal_strings_to_owned(input: &[u8], length: usize) -> IResult<&[u
 #[cfg(test)]
 mod tests {
     use super::*;
-    use nom::{Err, ErrorKind, Context, Needed};
+    use nom::{Err, Needed};
 
     #[test]
     fn case_post_script_table_pascal_strings() {

--- a/src/ttc_header.rs
+++ b/src/ttc_header.rs
@@ -1,5 +1,4 @@
 use nom::{be_u16, be_u32};
-use tables::Tag;
 use types::Offset32;
 
 /// The purpose of the TTC Header table is to locate the different Offset Tables within a TTC file.
@@ -106,7 +105,6 @@ named!(parse_ttc_header_v2<&[u8],TTCHeader>,
 mod tests {
     use super::*;
     use nom::{Err, ErrorKind, Context};
-    use tables::TableTag;
 
     #[test]
     fn case_ttc_header_v1_0() {

--- a/src/ttc_header.rs
+++ b/src/ttc_header.rs
@@ -19,6 +19,7 @@ impl TTCHeader {
     }
 
     /// Array of offsets to the OffsetTable for each font from the beginning of the file.
+    #[allow(dead_code)]
     pub fn offset_table(&self) -> &[u32] {
         &self.offset_table
     }
@@ -26,6 +27,7 @@ impl TTCHeader {
     /// There are two versions of the TTC Header: Version 1.0 has been used for TTC files without
     /// digital signatures. Version 2.0 can be used for TTC files with or without digital
     /// signatures.
+    #[allow(dead_code)]
     pub fn dsig(&self) -> Option<TTCDigitalSignature> {
         self.dsig
     }
@@ -40,11 +42,13 @@ pub struct TTCDigitalSignature {
 
 impl TTCDigitalSignature {
     /// The length (in bytes) of the DSIG table
+    #[allow(dead_code)]
     pub fn dsig_length(&self) -> u32 {
         self.dsig_length
     }
 
     /// The offset (in bytes) of the DSIG table from the beginning of the TTC
+    #[allow(dead_code)]
     pub fn dsig_offset(&self) -> u32 {
         self.dsig_offset
     }

--- a/src/types.rs
+++ b/src/types.rs
@@ -3,9 +3,6 @@
 //!
 //! https://docs.microsoft.com/en-gb/typography/opentype/spec/otff
 
-use std::{fmt, str};
-use tables::TableTag;
-
 /// Short offset to a table, same as uint16, NULL offset = 0x0000
 pub type Offset16 = u16;
 


### PR DESCRIPTION
- Remove unused imports
- Prefix unused variables with an underscore
- Add `#![allow(deprecated)]` for cases where the compiler cannot figure out a function is used within a macro or test
- Delete unused `ErrorKindExt` variants